### PR TITLE
Fix damage from previous GHC 7.6 compatibility patch

### DIFF
--- a/lifted-base.cabal
+++ b/lifted-base.cabal
@@ -41,14 +41,14 @@ Library
   Exposed-modules: Control.Exception.Lifted
                    Control.Concurrent.MVar.Lifted
                    Control.Concurrent.Chan.Lifted
-  if flag(base_4_6)
+                   Control.Concurrent.Lifted
+                   Data.IORef.Lifted
+                   System.Timeout.Lifted
+  if !flag(base_4_6)
     Exposed-modules: 
                    Control.Concurrent.QSem.Lifted
                    Control.Concurrent.QSemN.Lifted
                    Control.Concurrent.SampleVar.Lifted
-                   Control.Concurrent.Lifted
-                   Data.IORef.Lifted
-                   System.Timeout.Lifted
 
   Build-depends: base                 >= 3     && < 4.7
                , base-unicode-symbols >= 0.1.1 && < 0.3


### PR DESCRIPTION
The conditions in the previous patch were really just horribly wrong (System.Timeout was missing from builds not built with -fbase_4_6, for instance). I hope you can put out a new release shortly before too many people are bitten. Very sorry for the inconvenience.
