### PR TITLE
Drop monad-peel dep

### DIFF
--- a/lifted-base.cabal
+++ b/lifted-base.cabal
@@ -91,4 +91,3 @@ benchmark bench-lifted-base
                , transformers  >= 0.2 && < 0.4
                , criterion     >= 0.5 && < 0.7
                , monad-control >= 0.3 && < 0.4
-               , monad-peel    >= 0.1 && < 0.2


### PR DESCRIPTION
It seems like this dependency is not needed. Keeping it around can lead to dependency hell, as monad-peel requires an older version of transformers.
