### PR TITLE
Support Cabal 1.8

### DIFF
--- a/lifted-base.cabal
+++ b/lifted-base.cabal
@@ -10,7 +10,7 @@ Homepage:            https://github.com/basvandijk/lifted-base
 Bug-reports:         https://github.com/basvandijk/lifted-base/issues
 Category:            Control
 Build-type:          Custom
-Cabal-version:       >= 1.9.2
+Cabal-version:       >= 1.8
 Description:         @lifted-base@ exports IO operations from the base library lifted to
                      any instance of 'MonadBase' or 'MonadBaseControl'.
                      .


### PR DESCRIPTION
Gives warnings about the benchmark and test-suite sections, but these
do not prevent it from configuring and building correctly.

Closes #13
