### PR TITLE
Supporting GHC 7.8

### DIFF
--- a/Control/Exception/Lifted.hs
+++ b/Control/Exception/Lifted.hs
@@ -3,6 +3,7 @@
            , NoImplicitPrelude
            , ExistentialQuantification
            , FlexibleContexts
+           , ImpredicativeTypes
   #-}
 
 #if MIN_VERSION_base(4,3,0)

--- a/lifted-base.cabal
+++ b/lifted-base.cabal
@@ -46,7 +46,7 @@ Library
                    Control.Concurrent.QSemN.Lifted
                    Control.Concurrent.SampleVar.Lifted
 
-  Build-depends: base                 >= 3     && < 4.7
+  Build-depends: base                 >= 3     && < 5
                , base-unicode-symbols >= 0.1.1 && < 0.3
                , transformers-base    >= 0.4   && < 0.5
                , monad-control        >= 0.3   && < 0.4
@@ -64,7 +64,7 @@ test-suite test-lifted-base
   hs-source-dirs: test
 
   build-depends: lifted-base
-               , base                 >= 3     && < 4.7
+               , base                 >= 3     && < 5
                , transformers         >= 0.2   && < 0.4
                , transformers-base    >= 0.4   && < 0.5
                , monad-control        >= 0.3   && < 0.4
@@ -87,7 +87,7 @@ benchmark bench-lifted-base
   ghc-options:    -O2
 
   build-depends: lifted-base
-               , base          >= 3   && < 4.7
+               , base          >= 3   && < 5
                , transformers  >= 0.2 && < 0.4
                , criterion     >= 0.5 && < 0.7
                , monad-control >= 0.3 && < 0.4


### PR DESCRIPTION
With this patch, lifted-base can be compiled with both GHC 7.4.2 and GHC head.
