### PR TITLE
Fix preprocessor directives for GHC 7.6.3

### DIFF
--- a/Control/Concurrent/MVar/Lifted.hs
+++ b/Control/Concurrent/MVar/Lifted.hs
@@ -2,8 +2,7 @@
            , UnicodeSyntax
            , NoImplicitPrelude
            , FlexibleContexts
-           , TupleSections
-  #-}
+           , TupleSections #-}
 
 #if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}

--- a/Control/Exception/Lifted.hs
+++ b/Control/Exception/Lifted.hs
@@ -3,8 +3,7 @@
            , NoImplicitPrelude
            , ExistentialQuantification
            , FlexibleContexts
-           , ImpredicativeTypes
-  #-}
+           , ImpredicativeTypes #-}
 
 #if MIN_VERSION_base(4,3,0)
 {-# LANGUAGE RankNTypes #-} -- for mask


### PR DESCRIPTION
Fails to compile and install on GHC 7.6.3 (bottled from homebrew, on osx 10.8.5)

Complains about wrong preprocessor directive

```
Control/Exception/Lifted.hs:7:4:
     error: invalid preprocessing directive
      #-}
       ^
```

and

```
Control/Concurrent/MVar/Lifted.hs:6:4:
     error: invalid preprocessing directive
      #-}
       ^
```
