### PR TITLE
Updates for base-4.7.0 (GHC 7.8)

### DIFF
--- a/Control/Concurrent/Lifted.hs
+++ b/Control/Concurrent/Lifted.hs
@@ -55,9 +55,9 @@ module Control.Concurrent.Lifted
       -- * Communication abstractions
     , module Control.Concurrent.MVar.Lifted
     , module Control.Concurrent.Chan.Lifted
-#if !MIN_VERSION_base(4,6,0)
     , module Control.Concurrent.QSem.Lifted
     , module Control.Concurrent.QSemN.Lifted
+#if !MIN_VERSION_base(4,7,0)
     , module Control.Concurrent.SampleVar.Lifted
 #endif
 
@@ -115,9 +115,9 @@ import Control.Monad               ( void )
 -- from lifted-base (this package):
 import Control.Concurrent.MVar.Lifted
 import Control.Concurrent.Chan.Lifted
-#if !MIN_VERSION_base(4,6,0)
 import Control.Concurrent.QSem.Lifted
 import Control.Concurrent.QSemN.Lifted
+#if !MIN_VERSION_base(4,7,0)
 import Control.Concurrent.SampleVar.Lifted
 #endif
 import Control.Exception.Lifted ( throwTo

--- a/Control/Concurrent/MVar/Lifted.hs
+++ b/Control/Concurrent/MVar/Lifted.hs
@@ -42,6 +42,10 @@ module Control.Concurrent.MVar.Lifted
 #else
     , addMVarFinalizer
 #endif
+#if MIN_VERSION_base(4,7,0)
+    , withMVarMasked
+    , tryReadMVar
+#endif
     ) where
 
 
@@ -220,4 +224,14 @@ mkWeakMVar = liftBaseDiscard . MVar.mkWeakMVar
 addMVarFinalizer :: MonadBaseControl IO m => MVar a -> m () -> m ()
 addMVarFinalizer = liftBaseDiscard . MVar.addMVarFinalizer
 {-# INLINABLE addMVarFinalizer #-}
+#endif
+
+#if MIN_VERSION_base (4,7,0)
+-- | Generalized version of 'MVar.withMVarMasked'.
+withMVarMasked :: MonadBaseControl IO m => MVar a -> (a -> m b) -> m b
+withMVarMasked = liftBaseOp . MVar.withMVarMasked
+
+-- | Generalized version of 'MVar.tryReadMVar'.
+tryReadMVar :: MonadBase IO m => MVar a -> m (Maybe a)
+tryReadMVar = liftBase . MVar.tryReadMVar
 #endif

--- a/Control/Concurrent/QSem/Lifted.hs
+++ b/Control/Concurrent/QSem/Lifted.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/Control/Concurrent/QSemN/Lifted.hs
+++ b/Control/Concurrent/QSemN/Lifted.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/lifted-base.cabal
+++ b/lifted-base.cabal
@@ -37,14 +37,14 @@ Library
   Exposed-modules: Control.Exception.Lifted
                    Control.Concurrent.MVar.Lifted
                    Control.Concurrent.Chan.Lifted
+                   Control.Concurrent.QSem.Lifted
+                   Control.Concurrent.QSemN.Lifted
                    Control.Concurrent.Lifted
                    Data.IORef.Lifted
                    Foreign.Marshal.Utils.Lifted
                    System.Timeout.Lifted
-  if impl(ghc < 7.6)
+  if impl(ghc < 7.8)
     Exposed-modules:
-                   Control.Concurrent.QSem.Lifted
-                   Control.Concurrent.QSemN.Lifted
                    Control.Concurrent.SampleVar.Lifted
 
   Build-depends: base                 >= 3     && < 5


### PR DESCRIPTION
This adds the new `withMVarMasked` and `tryReadMVar` functions.  They seem to work in GHCI, but I haven't tested them extensively.

This also changes which modules are exported for GHC 7.6 - as `Control.Concurrent.QSem.Lifted` and `Control.Concurrent.QSemN.Lifted` weren't being exported - even though the corresponding modules haven't been removed from any published version of base.

I've tested compilation with GHC 7.4 and GHC 7.8.
