### PR TITLE
Unconditionally run ExceptT tests using transformers-compat

### DIFF
--- a/lifted-base.cabal
+++ b/lifted-base.cabal
@@ -66,7 +66,8 @@ test-suite test-lifted-base
   build-depends: lifted-base
                , base                 >= 3     && < 5
                , transformers         >= 0.3   && < 0.5
-               , transformers-base    >= 0.4   && < 0.5
+               , transformers-base    >= 0.4.4 && < 0.5
+               , transformers-compat  >= 0.3   && < 0.4
                , monad-control        >= 0.3   && < 1.1
                , HUnit                >= 1.2.2 && < 1.3
                , test-framework       >= 0.2.4 && < 0.9

--- a/test/test.hs
+++ b/test/test.hs
@@ -17,10 +17,7 @@ import Control.Monad.Trans.List
 import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.Reader
 import Control.Monad.Trans.Writer
-
-#if MIN_VERSION_transformers(0,4,0)
 import Control.Monad.Trans.Except
-#endif
 
 import Control.Monad.Trans.State
 import qualified Control.Monad.Trans.RWS as RWS
@@ -48,23 +45,17 @@ main = defaultMain
     , testSuite "MaybeT" $ fmap fromJust . runMaybeT
     , testSuite "ReaderT" $ flip runReaderT "reader state"
     , testSuite "WriterT" runWriterT'
-#if MIN_VERSION_transformers(0,4,0)
     , testSuite "ExceptT" runExceptT'
-#endif
     , testSuite "StateT" $ flip evalStateT "state state"
     , testSuite "RWST" $ \m -> runRWST' m "RWS in" "RWS state"
-#if MIN_VERSION_transformers(0,4,0)
     , testCase "ExceptT throwE" case_throwE
-#endif
     , testCase "WriterT tell" case_tell
     ]
   where
     runWriterT' :: Functor m => WriterT [Int] m a -> m a
     runWriterT' = fmap fst . runWriterT
-#if MIN_VERSION_transformers(0,4,0)
     runExceptT' :: Functor m => ExceptT String m () -> m ()
     runExceptT' = fmap (either (const ()) id) . runExceptT
-#endif
     runRWST' :: (Monad m, Functor m) => RWS.RWST r [Int] s m a -> r -> s -> m a
     runRWST' m r s = fmap fst $ RWS.evalRWST m r s
 
@@ -144,7 +135,6 @@ case_onException run = do
     k <- readIORef i
     k @?= 4
 
-#if MIN_VERSION_transformers(0,4,0)
 case_throwE :: Assertion
 case_throwE = do
     i <- newIORef one
@@ -154,7 +144,6 @@ case_throwE = do
         (liftBase $ writeIORef i 3)
     j <- readIORef i
     j @?= 3
-#endif
 
 case_tell :: Assertion
 case_tell = do


### PR DESCRIPTION
Since this package doesn't define ExceptT instances and doesn't export anything related to ExceptT this simply removes some duplication.

It also requires the newest version of transformers-base which is now using transformers-compat as well.

This is not yet mergable, it depends on https://github.com/basvandijk/monad-control/pull/26 being released.

Also see https://github.com/fpco/stackage/issues/439
