### PR TITLE
Fix GHC 7.10 warnings.

### DIFF
--- a/Control/Concurrent/Chan/Lifted.hs
+++ b/Control/Concurrent/Chan/Lifted.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 
 #if __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE Safe #-}
 #endif
 
 {- |

--- a/Control/Concurrent/Lifted.hs
+++ b/Control/Concurrent/Lifted.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP, NoImplicitPrelude, FlexibleContexts, RankNTypes #-}
 
 #if __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE Safe #-}
 #endif
 
 {- |

--- a/Control/Concurrent/MVar/Lifted.hs
+++ b/Control/Concurrent/MVar/Lifted.hs
@@ -4,7 +4,7 @@
            , TupleSections #-}
 
 #if __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE Safe #-}
 #endif
 
 {- |

--- a/Control/Concurrent/QSem/Lifted.hs
+++ b/Control/Concurrent/QSem/Lifted.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 
 #if __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE Safe #-}
 #endif
 
 {- |

--- a/Control/Concurrent/QSemN/Lifted.hs
+++ b/Control/Concurrent/QSemN/Lifted.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 
 #if __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE Safe #-}
 #endif
 
 {- |

--- a/Control/Exception/Lifted.hs
+++ b/Control/Exception/Lifted.hs
@@ -8,7 +8,7 @@
 #endif
 
 #if __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE Safe #-}
 #endif
 
 {- |

--- a/Data/IORef/Lifted.hs
+++ b/Data/IORef/Lifted.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 
 #if __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE Safe #-}
 #endif
 
 {- |

--- a/Foreign/Marshal/Utils/Lifted.hs
+++ b/Foreign/Marshal/Utils/Lifted.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 
 #if __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE Safe #-}
 #endif
 
 {- |

--- a/System/Timeout/Lifted.hs
+++ b/System/Timeout/Lifted.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP, NoImplicitPrelude, FlexibleContexts #-}
 
 #if __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE Safe #-}
 #endif
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
"Module Foo marked as Trustworthy but inferred as Safe."