### PR TITLE
Make benchmarks compile with modern criterion

### DIFF
--- a/bench/bench.hs
+++ b/bench/bench.hs
@@ -45,24 +45,28 @@ main = defaultMain
   , b "bracket_"  benchBracket_ MP.bracket_  MC.bracket_
   , b "catch"     benchCatch    MP.catch     MC.catch
   , b "try"       benchTry      MP.try       MC.try
-  , b "mask"      benchMask     mpMask       MC.mask
+
+  , bgroup "mask"
+    [ bench "monad-peel"    $ whnfIO $ benchMask mpMask
+    , bench "monad-control" $ whnfIO $ benchMask MC.mask
+    ]
 
   , bgroup "liftIOOp"
-    [ bench "monad-peel"    $ exe $ MP.liftIOOp   (E.bracket nop (\_ -> nop))
-                                                  (\_ -> nop)
-    , bench "monad-control" $ exe $ MC.liftBaseOp (E.bracket nop (\_ -> nop))
-                                                  (\_ -> nop)
+    [ bench "monad-peel"    $ whnfIO $ exe $ MP.liftIOOp   (E.bracket nop (\_ -> nop))
+                                                           (\_ -> nop)
+    , bench "monad-control" $ whnfIO $ exe $ MC.liftBaseOp (E.bracket nop (\_ -> nop))
+                                                           (\_ -> nop)
     ]
 
   , bgroup "liftIOOp_"
-    [ bench "monad-peel"    $ exe $ MP.liftIOOp_   (E.bracket_ nop nop) nop
-    , bench "monad-control" $ exe $ MC.liftBaseOp_ (E.bracket_ nop nop) nop
+    [ bench "monad-peel"    $ whnfIO $ exe $ MP.liftIOOp_   (E.bracket_ nop nop) nop
+    , bench "monad-control" $ whnfIO $ exe $ MC.liftBaseOp_ (E.bracket_ nop nop) nop
     ]
   ]
 
 b name bnch peel mndCtrl = bgroup name
-  [ bench "monad-peel"    $ bnch peel
-  , bench "monad-control" $ bnch mndCtrl
+  [ bench "monad-peel"    $ whnfIO $ bnch peel
+  , bench "monad-control" $ whnfIO $ bnch mndCtrl
   ]
 
 --------------------------------------------------------------------------------

--- a/lifted-base.cabal
+++ b/lifted-base.cabal
@@ -90,6 +90,6 @@ benchmark bench-lifted-base
   build-depends: lifted-base
                , base          >= 3   && < 5
                , transformers  >= 0.2 && < 0.5
-               , criterion     >= 0.5 && < 0.9
+               , criterion     >= 1   && < 1.2
                , monad-control >= 0.3 && < 1.1
-               , monad-peel    >= 0.1 && < 0.2
+               , monad-peel    >= 0.1 && < 0.3


### PR DESCRIPTION
I had to do some minor code changes to make things work, including sprinkling `whnfIO` in various places (since the type of `bench` changed in `criterion-1`) and avoiding the use of the `b` function with `mpMask`/`mask`, since there were some type inference issues involving `RankNTypes`.

Fixes #29.